### PR TITLE
replace jsx-loader to babel-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Switch to the directory containing `webpack.config.js` and run:
 
 ## 4. Compile-to-JS languages
 
-webpack's equivalent of browserify transforms and RequireJS plugins is a **loader**. Here's how you can teach webpack to load CoffeeScript and Facebook JSX+ES6 support (you must `npm install jsx-loader coffee-loader`):
+webpack's equivalent of browserify transforms and RequireJS plugins is a **loader**. Here's how you can teach webpack to load CoffeeScript and Facebook JSX+ES6 support (you must `npm install babel-loader coffee-loader`):
 
 ```js
 // webpack.config.js
@@ -72,7 +72,7 @@ module.exports = {
   module: {
     loaders: [
       { test: /\.coffee$/, loader: 'coffee-loader' },
-      { test: /\.js$/, loader: 'jsx-loader?harmony' } // loaders can take parameters as a querystring
+      { test: /\.js$/, loader: 'babel-loader?stage=0' } // loaders can take parameters as a querystring
     ]
   }
 };

--- a/example/modules/About.js
+++ b/example/modules/About.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 
 var About = React.createClass({

--- a/example/modules/App.js
+++ b/example/modules/App.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 var {Link, RouteHandler} = require('react-router');
 

--- a/example/modules/Home.js
+++ b/example/modules/Home.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 
 var Home = React.createClass({

--- a/example/modules/main.js
+++ b/example/modules/main.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var App = require('./App');
 var Home = require('./Home');
 var About = require('./About');

--- a/example/package.json
+++ b/example/package.json
@@ -10,18 +10,21 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "babel-core": "^5.6.15",
+    "babel-loader": "^5.2.2",
     "bundle-loader": "^0.5.0",
     "css-loader": "^0.9.0",
     "file-loader": "^0.7.2",
-    "jsx-loader": "^0.11.0",
     "less": "^1.7.5",
     "less-loader": "^0.7.7",
+    "node-libs-browser": "^0.5.2",
     "style-loader": "^0.8.0",
     "url-loader": "^0.5.5",
+    "webpack": "^1.9.13",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {
-    "react": "git://github.com/facebook/react.git#master",
-    "react-router": "git://github.com/rackt/react-router.git#master"
+    "react": "^0.13.3",
+    "react-router": "^0.13.3"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, loader: 'jsx-loader?harmony' },
+      { test: /\.js$/, loader: 'babel' },
       { test: /\.less$/, loader: 'style-loader!css-loader!less-loader' }, // use ! to chain loaders
       { test: /\.css$/, loader: 'style-loader!css-loader' },
       { test: /\.(png|jpg)$/, loader: 'url-loader?limit=8192' } // inline base64 URLs for <=8k images, direct URLs for the rest


### PR DESCRIPTION
Because react 0.14 will deprecate JSXTransformer this repo should use babel also. 
[Deprecating JSTransform and react-tools](http://facebook.github.io/react/blog/2015/06/12/deprecating-jstransform-and-react-tools.html#migrating-to-babel)