### PR TITLE
Clarifies example by adding webpack as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Then teach webpack those magic globals:
 ```js
 // webpack.config.js
 
+var webpack = require('webpack');
+
 // definePlugin takes raw strings and inserts them, so you can put strings of JS if you want.
 var definePlugin = new webpack.DefinePlugin({
   __DEV__: JSON.stringify(JSON.parse(process.env.BUILD_DEV || 'true')),


### PR DESCRIPTION
Added webpack as requirement to the magic globals example to clarify things a bit. Otherwise, if someone copies the example code to their webpack.config.js they would get an ReferenceError: webpack is not defined.