### PR TITLE
Install babel-loader & coffee-loader as dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Switch to the directory containing `webpack.config.js` and run:
 
 ## 4. Compile-to-JS languages
 
-webpack's equivalent of browserify transforms and RequireJS plugins is a **loader**. Here's how you can teach webpack to load CoffeeScript and Facebook JSX+ES6 support (you must `npm install babel-loader coffee-loader`):
+webpack's equivalent of browserify transforms and RequireJS plugins is a **loader**. Here's how you can teach webpack to load CoffeeScript and Facebook JSX+ES6 support (you must `npm install --save-dev babel-loader coffee-loader`):
 
 ```js
 // webpack.config.js


### PR DESCRIPTION
It is a good practice to install loaders as dev dependencies.
