### PR TITLE
Update example project files

### DIFF
--- a/example/modules/About.js
+++ b/example/modules/About.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 
 var About = React.createClass({

--- a/example/modules/App.js
+++ b/example/modules/App.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 var {Link, RouteHandler} = require('react-router');
 

--- a/example/modules/Home.js
+++ b/example/modules/Home.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var React = require('react');
 
 var Home = React.createClass({

--- a/example/modules/main.js
+++ b/example/modules/main.js
@@ -1,5 +1,3 @@
-/** @jsx React.DOM */
-
 var App = require('./App');
 var Home = require('./Home');
 var About = require('./About');

--- a/example/package.json
+++ b/example/package.json
@@ -10,14 +10,16 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "babel-core": "^5.8.23",
+    "babel-loader": "^5.3.2",
     "bundle-loader": "^0.5.0",
     "css-loader": "^0.9.0",
     "file-loader": "^0.7.2",
-    "jsx-loader": "^0.11.0",
     "less": "^1.7.5",
     "less-loader": "^0.7.7",
     "style-loader": "^0.8.0",
     "url-loader": "^0.5.5",
+    "webpack": "^1.12.1",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {

--- a/example/package.json
+++ b/example/package.json
@@ -19,11 +19,10 @@
     "less-loader": "^0.7.7",
     "style-loader": "^0.8.0",
     "url-loader": "^0.5.5",
-    "webpack": "^1.12.1",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {
-    "react": "git://github.com/facebook/react.git#master",
-    "react-router": "git://github.com/rackt/react-router.git#master"
+    "react": "^0.13.3",
+    "react-router": "^0.13.3"
   }
 }

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   module: {
     loaders: [
-      { test: /\.js$/, loader: 'jsx-loader?harmony' },
+      { test: /\.js$/, loader: 'babel-loader' },
       { test: /\.less$/, loader: 'style-loader!css-loader!less-loader' }, // use ! to chain loaders
       { test: /\.css$/, loader: 'style-loader!css-loader' },
       { test: /\.(png|jpg)$/, loader: 'url-loader?limit=8192' } // inline base64 URLs for <=8k images, direct URLs for the rest


### PR DESCRIPTION
As of september 2015, the `example` for this howto was not working and `npm install` threw several errors (mostly because of deprecations and dependencies on unstable releases).

This PR fixes those issues.