### PR TITLE
Using ExtendedDefinePlugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ module.exports = {
 
 ## 6. Feature flags
 
-We have code we want to gate only to our dev environments (like logging) and our internal dogfooding servers (like unreleased features we're testing with employees). In your code, refer to magic globals:
+We have code we want to gate only to our dev environments (like logging) and our internal dogfooding servers (like unreleased features we're testing with employees). In your code, refer to magic globals (you must `npm install extended-define-webpack-plugin`):
 
 ```js
 if (__DEV__) {
@@ -155,10 +155,12 @@ Then teach webpack those magic globals:
 ```js
 // webpack.config.js
 
-// definePlugin takes raw strings and inserts them, so you can put strings of JS if you want.
-var definePlugin = new webpack.DefinePlugin({
-  __DEV__: JSON.stringify(JSON.parse(process.env.BUILD_DEV || 'true')),
-  __PRERELEASE__: JSON.stringify(JSON.parse(process.env.BUILD_PRERELEASE || 'false'))
+// ExtendedDefinePlugin is an extended version of webpack.definePlugin that takes raw strings and inserts them, so you can put strings of JS if you want.
+var ExtendedDefinePlugin = require('extended-define-webpack-plugin');
+
+var definePlugin = new ExtendedDefinePlugin({
+  __DEV__: JSON.parse(process.env.BUILD_DEV || 'true'),
+  __PRERELEASE__: JSON.parse(process.env.BUILD_PRERELEASE || 'false')
 });
 
 module.exports = {


### PR DESCRIPTION
This guide helped me a lot learning webpack basics
I wrote a wrapper for define plugin, I wish you to consider using it in your guide

it does the `JSON.stringify()` part for you so you can also include config files like this:

``` js
// app.config.js
module.exports = {
    dev: {
        api_key: '1234567890ABCDEFG'
        fb_conf: {
          use_social: true,
          api_key: '123456790'
        }
    },
    prod: {
        api_key: '1234567890ABCDEFG'
        fb_conf: {
          use_social: true,
          api_key: '123456790'
        }
    }
};
```

``` js
// webpack.config.js

var ExtendedDefinePlugin = require('extended-define-webpack-plugin');
var appConfig = require('./app.config.js');

module.exports = {
  // ...
  plugins: [
    /* ..., */
    new ExtendedDefinePlugin({
      APP_CONFIG: appConfig[process.env.NODE_ENV],
    })
  ]
};
```
