### PR TITLE
Fix build errors described in #64

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -10,8 +10,10 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "^5.8.23",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.2.0",
+    "babel-loader": "^6.2.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
     "bundle-loader": "^0.5.0",
     "css-loader": "^0.9.0",
     "file-loader": "^0.7.2",
@@ -19,6 +21,7 @@
     "less-loader": "^0.7.7",
     "style-loader": "^0.8.0",
     "url-loader": "^0.5.5",
+    "webpack": "^1.12.14",
     "webpack-dev-server": "^1.6.5"
   },
   "dependencies": {


### PR DESCRIPTION
I finally tracked down 3 changes that need to be made to fix #64:
- bump `babel-core` and `babel-loader` to version 6.x
- add `babel-preset-es2015` and `babel-preset-react` modules
- add `webpack` module

You can now run the following commands to fire up the example code:

``` sh
$ cd example
$ npm install
$ npm run start
```

Then point your browser at either of the following URLs:
- [localhost:8080](http://localhost:8080/)
- [localhost:8080/webpack-dev-server/](http://localhost:8080/webpack-dev-server/)

Note that in order for the [How to invoke webpack](https://github.com/petehunt/webpack-howto#3-how-to-invoke-webpack) instructions in the README to work, you will additionally have to install `webpack` globally:

``` sh
$ npm install -g webpack
```
